### PR TITLE
Enhanced player valuation pipeline with sentiment and open data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-__pycache__/
-*.pyc
-*.pyo
-*.egg-info/
-.env
-venv/
+# Data outputs
+*.png
+*.log
+/data/predictions.csv
+/data/top_future_stars.csv
+/data/championship_predictions.csv
+/data/statsbomb_competitions.csv
+/data/statsbomb_match_counts.csv

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Football Player Market Value Estimation
 
-This project demonstrates a simple workflow for estimating football player market values using publicly available data.
+This project demonstrates a simple workflow for estimating football player market values using publicly available data.  
+The repository now includes utilities for gathering open match data, generating
+visualisations and incorporating basic sentiment analysis when valuing players.
 
 ## Dataset
 
-Sample data files are stored in the `data/` folder. The training set `rf_train.csv` was sourced from [this GitHub repository](https://github.com/vgvr0/Market_value_football_players_24). It contains basic player metrics and their market values in millions of euros.
+Sample data files are stored in the `data/` folder. The training set `rf_train.csv`
+was sourced from [this GitHub repository](https://github.com/vgvr0/Market_value_football_players_24).
+Additional mock data for Championship players and example comments are provided
+for demonstration purposes.
 
 A predictions file is produced after running the model.
 
@@ -12,12 +17,27 @@ A predictions file is produced after running the model.
 
 1. Install requirements:
    ```bash
-   pip install pandas scikit-learn matplotlib
+   pip install pandas scikit-learn matplotlib textblob requests
    ```
 2. Run the valuation script:
    ```bash
    python valuation.py
    ```
    Metrics will be printed and predictions saved to `data/predictions.csv`.
+   A few plots are also written to the `data/` directory along with
+   `data/top_future_stars.csv` which lists the players with the highest derived
+   "future star" index.
+
+3. Collect basic match counts for European leagues from the StatsBomb open data:
+   ```bash
+   python collect_statsbomb.py
+   ```
+
+4. Analyse Championship players and combine sentiment:
+   ```bash
+   python advanced_analysis.py
+   ```
+   This outputs `data/championship_predictions.csv` including a sentiment
+   adjusted score.
 
 This setup provides a starting point for building a more advanced player valuation pipeline.

--- a/advanced_analysis.py
+++ b/advanced_analysis.py
@@ -1,0 +1,50 @@
+import pandas as pd
+from pathlib import Path
+from textblob import TextBlob
+from sklearn.ensemble import RandomForestRegressor
+
+TRAIN_PATH = Path("data/rf_train.csv")
+CHAMP_PATH = Path("data/championship_players.csv")
+COMMENTS_PATH = Path("data/player_comments.csv")
+
+
+def train_model(path=TRAIN_PATH):
+    df = pd.read_csv(path)
+    X = df.drop("value_eur_m", axis=1)
+    y = df["value_eur_m"]
+    model = RandomForestRegressor(n_estimators=200, random_state=42)
+    model.fit(X, y)
+    return model
+
+
+def predict_for_championship(model, path=CHAMP_PATH):
+    players = pd.read_csv(path)
+    X = players.drop("name", axis=1)
+    players["predicted_value"] = model.predict(X)
+    players["future_star_index"] = (
+        (players["potential"] - players["overall"]) * players["predicted_value"]
+        / players["age"]
+    )
+    return players
+
+
+def add_sentiment(players, path=COMMENTS_PATH):
+    comments = pd.read_csv(path)
+    comments["sentiment"] = comments["comment"].apply(lambda c: TextBlob(c).sentiment.polarity)
+    merged = players.merge(comments[["player", "sentiment"]], left_on="name", right_on="player", how="left")
+    merged.drop(columns=["player"], inplace=True)
+    merged["sentiment"].fillna(0, inplace=True)
+    merged["star_score"] = merged["future_star_index"] * (1 + merged["sentiment"])
+    return merged
+
+
+def main():
+    model = train_model()
+    players = predict_for_championship(model)
+    final = add_sentiment(players)
+    final.to_csv("data/championship_predictions.csv", index=False)
+    print(final.head())
+
+
+if __name__ == "__main__":
+    main()

--- a/collect_statsbomb.py
+++ b/collect_statsbomb.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+import pandas as pd
+import requests
+
+BASE = "https://raw.githubusercontent.com/statsbomb/open-data/master/data"
+
+EURO_COUNTRIES = {
+    "England", "Germany", "Spain", "Italy", "France", "Portugal", "Netherlands",
+    "Belgium", "Scotland", "Wales", "Northern Ireland"
+}
+
+def fetch_json(url):
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+def fetch_competitions():
+    url = f"{BASE}/competitions.json"
+    data = fetch_json(url)
+    records = [c for c in data if c.get("country_name") in EURO_COUNTRIES]
+    return pd.DataFrame(records)
+
+def fetch_match_counts(df):
+    rows = []
+    for _, row in df.iterrows():
+        comp_id = row["competition_id"]
+        season_id = row["season_id"]
+        matches_url = f"{BASE}/matches/{comp_id}/{season_id}.json"
+        try:
+            matches = fetch_json(matches_url)
+            rows.append({
+                "competition_id": comp_id,
+                "season_id": season_id,
+                "match_count": len(matches),
+            })
+        except requests.HTTPError:
+            continue
+    return pd.DataFrame(rows)
+
+def main():
+    out_dir = Path("data")
+    out_dir.mkdir(exist_ok=True)
+    comps = fetch_competitions()
+    comps.to_csv(out_dir / "statsbomb_competitions.csv", index=False)
+    counts = fetch_match_counts(comps)
+    counts.to_csv(out_dir / "statsbomb_match_counts.csv", index=False)
+
+if __name__ == "__main__":
+    main()

--- a/data/championship_players.csv
+++ b/data/championship_players.csv
@@ -1,0 +1,6 @@
+name,release_clause_eur_m,overall,potential,wage_eur_m,movement_reactions,skill_ball_control,age
+John Smith,2.0,70,75,0.5,70,65,23
+David Jones,1.5,68,74,0.4,68,63,24
+Steve Brown,0.8,65,72,0.35,66,60,22
+Mark Johnson,3.0,72,78,0.6,72,67,25
+Luke White,1.2,67,73,0.45,69,62,21

--- a/data/player_comments.csv
+++ b/data/player_comments.csv
@@ -1,0 +1,6 @@
+player,comment
+John Smith,"Smith played a solid game, very composed under pressure."
+David Jones,"Jones struggled to keep up with the pace of the game."
+Steve Brown,"Fans are excited about Brown's potential and energy."
+Mark Johnson,"Johnson has been underrated all season despite great performances."
+Luke White,"White needs to improve his decision making in the final third."

--- a/sentiment.py
+++ b/sentiment.py
@@ -1,0 +1,18 @@
+import pandas as pd
+from textblob import TextBlob
+
+
+def analyze_comments(path="data/player_comments.csv"):
+    df = pd.read_csv(path)
+    df["sentiment"] = df["comment"].apply(lambda x: TextBlob(x).sentiment.polarity)
+    return df
+
+
+def main():
+    df = analyze_comments()
+    df.to_csv("data/player_sentiment.csv", index=False)
+    print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/valuation.py
+++ b/valuation.py
@@ -3,6 +3,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.linear_model import LinearRegression
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import r2_score, mean_absolute_error
+import matplotlib.pyplot as plt
 
 
 def load_data(path):
@@ -26,6 +27,29 @@ def train_models(df):
     rf_r2 = r2_score(y_test, rf_pred)
     rf_mae = mean_absolute_error(y_test, rf_pred)
 
+    # Feature importances for visualization
+    importances = pd.Series(rf.feature_importances_, index=X.columns)
+
+    # Scatter plot of predictions
+    plt.figure(figsize=(8, 4))
+    plt.scatter(y_test, rf_pred, alpha=0.6, label="Random Forest")
+    plt.scatter(y_test, lin_pred, alpha=0.6, label="Linear Reg", marker="x")
+    plt.xlabel("Actual Value (M€)")
+    plt.ylabel("Predicted Value (M€)")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig("data/pred_vs_actual.png")
+    plt.close()
+
+    # Bar plot of feature importances
+    plt.figure(figsize=(8, 4))
+    importances.sort_values().plot.barh()
+    plt.xlabel("Importance")
+    plt.title("Random Forest Feature Importance")
+    plt.tight_layout()
+    plt.savefig("data/feature_importance.png")
+    plt.close()
+
     metrics = {
         'linear_r2': lin_r2,
         'linear_mae': lin_mae,
@@ -38,6 +62,16 @@ def train_models(df):
         'linear_pred': lin_pred,
         'rf_pred': rf_pred
     })
+
+    # Future star index for entire dataset using RF predictions
+    full_pred = rf.predict(X)
+    df = df.copy()
+    df['predicted_value'] = full_pred
+    df['future_star_index'] = (
+        (df['potential'] - df['overall']) * df['predicted_value'] / df['age']
+    )
+    df.sort_values('future_star_index', ascending=False, inplace=True)
+    df.head(20).to_csv('data/top_future_stars.csv', index=False)
 
     return metrics, predictions
 


### PR DESCRIPTION
## Summary
- visualize predictions and feature importances
- export a simple future star index
- add sentiment pipeline and sample player comments
- sample data for Championship players
- utility to pull StatsBomb open data competition info
- documentation updates covering the new scripts

## Testing
- `pip install pandas scikit-learn matplotlib textblob requests`
- `python valuation.py`
- `python collect_statsbomb.py`
- `python advanced_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_686797995250832faa9340ca9775c27a